### PR TITLE
build: run Prettier on changed files only before each commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   },
   "lint-staged": {
     "**/*.+(js|json|css|html|md)": [
+      "prettier",
       "jest --findRelatedTests"
     ]
   },


### PR DESCRIPTION
Prevent someone without Prettier editor plugin from committing unformatted code

close #125
