### PR TITLE
feat(number-fields): add the inputMode attribute to RGB/HSL value fields

### DIFF
--- a/src/blocks/FormNumberSmall.js
+++ b/src/blocks/FormNumberSmall.js
@@ -31,7 +31,9 @@ const padding = {
     formNumberSmall.whitespace.belowInputValue,
 };
 
-FormNumberSmall.Input = styled(Input)`
+FormNumberSmall.Input = styled(Input).attrs(props => ({
+  inputMode: 'decimal',
+}))`
   ${typescale.medium}
   border-radius: 100%;
   height: 100%;

--- a/src/blocks/FormNumberSmall.test.js
+++ b/src/blocks/FormNumberSmall.test.js
@@ -111,6 +111,7 @@ describe('renders UI correctly', () => {
         <input
           autocomplete="off"
           class="c0 c1"
+          inputmode="decimal"
           type="text"
         />
       </div>


### PR DESCRIPTION
show the number pad instead of the qwerty keyboard when the mobile user taps the value fields

close #157
