### PR TITLE
test(remify.js): add tests for invalid arguments

### DIFF
--- a/src/utils/remify.js
+++ b/src/utils/remify.js
@@ -1,6 +1,16 @@
 import round from './round';
 
 function remify(px) {
+  if (px === undefined) {
+    throw new Error(
+      'The argument is missing. Provide a number of the pixel value to be converted into rem.',
+    );
+  }
+  if (typeof px !== 'number') {
+    throw new Error(
+      `The argument must be a number, but you provided a ${typeof px}`,
+    );
+  }
   const oneRemInPx = 16;
   function stringify(number) {
     return `${number.toString()}rem`;

--- a/src/utils/remify.spec.js
+++ b/src/utils/remify.spec.js
@@ -18,3 +18,23 @@ cases(
     },
   },
 );
+
+cases(
+  'returns an error when the argument is not a number',
+  options => {
+    expect(() => {
+      remify(options.inputs);
+    }).toThrow(options.outputs);
+  },
+  {
+    missing: {
+      inputs: undefined,
+      outputs:
+        'The argument is missing. Provide a number of the pixel value to be converted into rem.',
+    },
+    string: {
+      inputs: '16',
+      outputs: 'The argument must be a number, but you provided a string',
+    },
+  },
+);


### PR DESCRIPTION
show the meaningful error message when the argument for remify() is invalid
