### PR TITLE
fix(sectioncolorpalette.js): hide the overflowing canvas element for narrow screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "triangulum-color-picker",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A front-end web app to pick tints and shades of a hue by luminance and by chroma, to make our color choice more logical and more intuitive",
   "main": "pages/index.js",
   "scripts": {

--- a/src/blocks/SectionColorPalette.js
+++ b/src/blocks/SectionColorPalette.js
@@ -3,11 +3,18 @@ import styled from 'styled-components';
 import {mediaQuery} from 'src/utils/breakpoints';
 
 const SectionColorPalette = styled.section`
+  /* Fix #178: https://github.com/masakudamatsu/triangulum-color-picker/issues/178 */
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  width: 100vw;
   @media only screen and ${mediaQuery.twoColumns} {
     order: 1;
+    width: auto;
   }
   @media only screen and ${mediaQuery.threeColumns} {
     order: 0;
+    width: auto;
   }
 `;
 

--- a/src/blocks/SectionColorPalette.test.js
+++ b/src/blocks/SectionColorPalette.test.js
@@ -9,11 +9,25 @@ const mockProps = {};
 test('renders UI correctly', () => {
   const {container} = render(<SectionColorPalette {...mockProps} />);
   expect(container).toMatchInlineSnapshot(`
+    .c0 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: center;
+      -webkit-justify-content: center;
+      -ms-flex-pack: center;
+      justify-content: center;
+      overflow: hidden;
+      width: 100vw;
+    }
+
     @media only screen and (min-width:57.6625rem) {
       .c0 {
         -webkit-order: 1;
         -ms-flex-order: 1;
         order: 1;
+        width: auto;
       }
     }
 
@@ -22,6 +36,7 @@ test('renders UI correctly', () => {
         -webkit-order: 0;
         -ms-flex-order: 0;
         order: 0;
+        width: auto;
       }
     }
 


### PR DESCRIPTION
prevent the page from moving horizontally with fingers on the mobile device screens

fix #178
