### PR TITLE
fix(globalstyle.js): disable overscroll for <html>

### DIFF
--- a/src/utils/GlobalStyle.js
+++ b/src/utils/GlobalStyle.js
@@ -320,6 +320,7 @@ input {
 :root { /* The background-color on the body element won't spread over the entire page for some reason. */
   background-color: ${color.backgroundFallback}; // fallback & paint outside the viewport so scrolling to the top/bottom won't reveal white background
   background-image: ${color.background};
+  overscroll-behavior: none;
 }
 
 body {


### PR DESCRIPTION
prevent header and footer from bouncing with scroll

close #187