### PR TITLE
fix(globalstyle.js): disable overscroll for <body>

### DIFF
--- a/src/utils/GlobalStyle.js
+++ b/src/utils/GlobalStyle.js
@@ -324,6 +324,7 @@ input {
 
 body {
   color: ${color.font};
+  overscroll-behavior: none;
 }
 
 `;


### PR DESCRIPTION
prevent header and footer from bouncing with scroll

close #187